### PR TITLE
Wrap error to allow for better error handling

### DIFF
--- a/decodingFuncs.go
+++ b/decodingFuncs.go
@@ -223,7 +223,7 @@ func decodeFloat64(r reader) (v float64, err error) {
 func decodeBytes(r reader, in *[]byte) (err error) {
 	var bsLength int
 	if bsLength, err = decodeInt(r); err != nil {
-		err = fmt.Errorf("error decoding bytes length: %v", err)
+		err = fmt.Errorf("error decoding bytes length: %w", err)
 		return
 	}
 


### PR DESCRIPTION
Wrapping the error properly allows for real world use cases. On our case we want to add new fields to the struct and keep compatibility with the data encoded in the past.

```go
func (data *Data) UnmarshalEnkodo(dec *enkodo.Decoder) error {
  var err error
  
  if data.OldField, err = dec.String(); err != nil {
    return err
  }

  if data.NewField, err = dec.String(); err != nil {
    if errors.Is(err, io.EOF) {
      return nil // ok, data was encoded without new field
    }
    return err
  }
}
```